### PR TITLE
bugfix: removed link to manifest.json as the file doesn't exist in the repo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,6 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/ico/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="/assets/ico/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/ico/favicon-16x16.png">
-  <link rel="manifest" href="/manifest.json">
   <meta name="msapplication-TileColor" content="#f2724b">
   <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
   <meta name="theme-color" content="#f2724b">


### PR DESCRIPTION
teradata.github.io references manifest.json but the file doesn't exist. As a result, users are getting the following error in the console. This PR removes the link.

GET https://teradata.github.io/manifest.json 404
manifest.json:1 Manifest: Line: 1, column: 1, Syntax error.