### PR TITLE
Add Google Tag Manager

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-TJ5VMHD');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="utf-8">
   <title>Teradata Open Source</title>
   <base href="/">
@@ -94,6 +101,10 @@
   </style>
 </head>
 <body class="bgc-contrast">
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TJ5VMHD"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <td-app>
     <div style="padding: 20%;text-align:center;">
       <mat-icon _ngcontent-c1="" class="mat-icon" role="img" svgicon="assets:teradata" aria-hidden="true" ng-reflect-svg-icon="assets:teradata">


### PR DESCRIPTION
## Description

I'm trying to understand more about the visitors who come to teradata.github.io. The only thing that I can currently see is GitHub pages metrics. They are pretty thin. 
This PR adds Google Tag Manager. Google Tag Manager will be configured with Google Analytics. It will give us ability to better understand who and why comes to the website.
### What's included?

- GTM markup

#### Test Steps

- once the website gets deployed, confirm that Google Analytics is collecting metrics

##### Screenshots or link to CodePen/Plunker/JSfiddle

N/A